### PR TITLE
Lowmem

### DIFF
--- a/mldftdat/analyzers.py
+++ b/mldftdat/analyzers.py
@@ -114,11 +114,11 @@ class ElectronAnalyzer(ABC):
         self.mo_vals = get_mo_vals(self.ao_vals, self.mo_coeff)
 
         self.assign_num_chunks(self.ao_vals.shape, self.ao_vals.dtype)
-        print("NUMBER OF CHUNKS", self.num_chunks, self.ao_vals.dtype, psutil.virtual_memory().available // 1e6)
+        print("NUMBER OF CHUNKS", self.calc_type, self.num_chunks, self.ao_vals.dtype, psutil.virtual_memory().available // 1e6)
 
         if self.num_chunks > 1:
             self.ao_vele_mat = get_vele_mat_generator(self.mol, self.grid.coords,
-                                                self.num_chunks, self.ao_vals)
+                                                self.num_chunks)
         else:
             self.ao_vele_mat = get_vele_mat(self.mol, self.grid.coords)
             print('AO VELE MAT', self.ao_vele_mat.nbytes, self.ao_vele_mat.shape)
@@ -172,8 +172,7 @@ class RHFAnalyzer(ElectronAnalyzer):
                                                     self.jmat, self.kmat)
         if self.num_chunks > 1:
             self.mo_vele_mat = get_vele_mat_generator(self.mol, self.grid.coords,
-                                                self.num_chunks, self.mo_vals,
-                                                self.mo_coeff)
+                                                self.num_chunks, self.mo_coeff)
         else:
             self.mo_vele_mat = get_mo_vele_mat(self.ao_vele_mat, self.mo_coeff)
             print("MO VELE MAT", self.mo_vele_mat.nbytes, psutil.virtual_memory().available // 1e6)
@@ -235,11 +234,9 @@ class UHFAnalyzer(ElectronAnalyzer):
                                                     self.jmat, self.kmat)
         if self.num_chunks > 1:
             self.mo_vele_mat = [get_vele_mat_generator(self.mol, self.grid.coords,
-                                                self.num_chunks, self.mo_vals[0],
-                                                self.mo_coeff[0]),\
+                                                self.num_chunks, self.mo_coeff[0]),\
                                 get_vele_mat_generator(self.mol, self.grid.coords,
-                                                self.num_chunks, self.mo_vals[1],
-                                                self.mo_coeff[1])]
+                                                self.num_chunks, self.mo_coeff[1])]
         else:
             self.mo_vele_mat = get_mo_vele_mat(self.ao_vele_mat, self.mo_coeff)
 

--- a/mldftdat/external/pyscf_ccsd_rdm.py
+++ b/mldftdat/external/pyscf_ccsd_rdm.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python
+# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Qiming Sun <osirpt.sun@gmail.com>
+# Edits by Kyle Bystrom <kylebystrom@gmail.com>
+#
+
+import time
+import numpy
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf import ao2mo
+from pyscf.cc import ccsd
+
+#
+# JCP, 95, 2623
+# JCP, 95, 2639
+#
+
+def _gamma1_intermediates(mycc, t1, t2, l1, l2):
+    nocc, nvir = t1.shape
+    doo =-numpy.einsum('ja,ia->ij', t1, l1)
+    dvv = numpy.einsum('ia,ib->ab', t1, l1)
+    xtv = numpy.einsum('ie,me->im', t1, l1)
+    dvo = t1.T - numpy.einsum('im,ma->ai', xtv, t1)
+    theta = t2 * 2 - t2.transpose(0,1,3,2)
+    doo -= lib.einsum('jkab,ikab->ij', theta, l2)
+    dvv += lib.einsum('jica,jicb->ab', theta, l2)
+    xt1  = lib.einsum('mnef,inef->mi', l2, theta)
+    xt2  = lib.einsum('mnaf,mnef->ea', l2, theta)
+    dvo += numpy.einsum('imae,me->ai', theta, l1)
+    dvo -= numpy.einsum('mi,ma->ai', xt1, t1)
+    dvo -= numpy.einsum('ie,ae->ai', t1, xt2)
+    dov = l1
+    return doo, dov, dvo, dvv
+
+# gamma2 intermediates in Chemist's notation
+def _gamma2_intermediates(mycc, t1, t2, l1, l2, compress_vvvv=False):
+    f = lib.H5TmpFile()
+    _gamma2_outcore(mycc, t1, t2, l1, l2, f, compress_vvvv)
+    d2 = (f['dovov'].value, f['dvvvv'].value, f['doooo'].value, f['doovv'].value,
+          f['dovvo'].value, None,             f['dovvv'].value, f['dooov'].value)
+    return d2
+
+def _gamma2_outcore(mycc, t1, t2, l1, l2, h5fobj, compress_vvvv=False):
+    log = logger.Logger(mycc.stdout, mycc.verbose)
+    nocc, nvir = t1.shape
+    nov = nocc * nvir
+    nvir_pair = nvir * (nvir+1) //2
+    dtype = numpy.result_type(t1, t2, l1, l2).char
+    if compress_vvvv:
+        dvvvv = h5fobj.create_dataset('dvvvv', (nvir_pair,nvir_pair), dtype)
+    else:
+        dvvvv = h5fobj.create_dataset('dvvvv', (nvir,nvir,nvir,nvir), dtype)
+    dovvo = h5fobj.create_dataset('dovvo', (nocc,nvir,nvir,nocc), dtype,
+                                  chunks=(nocc,1,nvir,nocc))
+    fswap = lib.H5TmpFile()
+
+    time1 = time.clock(), time.time()
+    pvOOv = lib.einsum('ikca,jkcb->aijb', l2, t2)
+    moo = numpy.einsum('dljd->jl', pvOOv) * 2
+    mvv = numpy.einsum('blld->db', pvOOv) * 2
+    gooov = lib.einsum('kc,cija->jkia', t1, pvOOv)
+    fswap['mvOOv'] = pvOOv
+    pvOOv = None
+
+    pvoOV = -lib.einsum('ikca,jkbc->aijb', l2, t2)
+    theta = t2 * 2 - t2.transpose(0,1,3,2)
+    pvoOV += lib.einsum('ikac,jkbc->aijb', l2, theta)
+    moo += numpy.einsum('dljd->jl', pvoOV)
+    mvv += numpy.einsum('blld->db', pvoOV)
+    gooov -= lib.einsum('jc,cika->jkia', t1, pvoOV)
+    fswap['mvoOV'] = pvoOV
+    pvoOV = None
+
+    mia =(numpy.einsum('kc,ikac->ia', l1, t2) * 2
+        - numpy.einsum('kc,ikca->ia', l1, t2))
+    mab = numpy.einsum('kc,kb->cb', l1, t1)
+    mij = numpy.einsum('kc,jc->jk', l1, t1) + moo*.5
+
+    tau = numpy.einsum('ia,jb->ijab', t1, t1)
+    tau += t2
+    goooo = lib.einsum('ijab,klab->ijkl', tau, l2)*.5
+    h5fobj['doooo'] = (goooo.transpose(0,2,1,3)*2 -
+                       goooo.transpose(0,3,1,2)).conj()
+
+    gooov += numpy.einsum('ji,ka->jkia', -.5*moo, t1)
+    gooov += lib.einsum('la,jkil->jkia', 2*t1, goooo)
+    gooov -= lib.einsum('ib,jkba->jkia', l1, tau)
+    gooov = gooov.conj()
+    gooov -= lib.einsum('jkba,ib->jkia', l2, t1)
+    h5fobj['dooov'] = gooov.transpose(0,2,1,3)*2 - gooov.transpose(1,2,0,3)
+    tau = goovo = None
+    time1 = log.timer_debug1('rdm intermediates pass1', *time1)
+
+    goovv = numpy.einsum('ia,jb->ijab', mia.conj(), t1.conj())
+    max_memory = max(0, mycc.max_memory - lib.current_memory()[0])
+    unit = nocc**2*nvir*6
+    blksize = min(nocc, nvir, max(ccsd.BLKMIN, int(max_memory*.95e6/8/unit)))
+    doovv = h5fobj.create_dataset('doovv', (nocc,nocc,nvir,nvir), dtype,
+                                  chunks=(nocc,nocc,1,nvir))
+
+    log.debug1('rdm intermediates pass 2: block size = %d, nvir = %d in %d blocks',
+               blksize, nvir, int((nvir+blksize-1)/blksize))
+    for p0, p1 in lib.prange(0, nvir, blksize):
+        tau = numpy.einsum('ia,jb->ijab', t1[:,p0:p1], t1)
+        tau += t2[:,:,p0:p1]
+        tmpoovv  = lib.einsum('ijkl,klab->ijab', goooo, tau)
+        tmpoovv -= lib.einsum('jk,ikab->ijab', mij, tau)
+        tmpoovv -= lib.einsum('cb,ijac->ijab', mab, t2[:,:,p0:p1])
+        tmpoovv -= lib.einsum('bd,ijad->ijab', mvv*.5, tau)
+        tmpoovv += .5 * tau
+        tmpoovv = tmpoovv.conj()
+        tmpoovv += .5 * l2[:,:,p0:p1]
+        goovv[:,:,p0:p1] += tmpoovv
+
+        pvOOv = fswap['mvOOv'][p0:p1]
+        pvoOV = fswap['mvoOV'][p0:p1]
+        gOvvO = lib.einsum('kiac,jc,kb->iabj', l2[:,:,p0:p1], t1, t1)
+        gOvvO += numpy.einsum('aijb->iabj', pvOOv)
+        govVO = numpy.einsum('ia,jb->iabj', l1[:,p0:p1], t1)
+        govVO -= lib.einsum('ikac,jc,kb->iabj', l2[:,:,p0:p1], t1, t1)
+        govVO += numpy.einsum('aijb->iabj', pvoOV)
+        dovvo[:,p0:p1] = 2*govVO + gOvvO
+        doovv[:,:,p0:p1] = (-2*gOvvO - govVO).transpose(3,0,1,2).conj()
+        gOvvO = govVO = None
+
+        tau -= t2[:,:,p0:p1] * .5
+        for q0, q1 in lib.prange(0, nvir, blksize):
+            goovv[:,:,q0:q1,:] += lib.einsum('dlib,jlda->ijab', pvOOv, tau[:,:,:,q0:q1]).conj()
+            goovv[:,:,:,q0:q1] -= lib.einsum('dlia,jldb->ijab', pvoOV, tau[:,:,:,q0:q1]).conj()
+            tmp = pvoOV[:,:,:,q0:q1] + pvOOv[:,:,:,q0:q1]*.5
+            goovv[:,:,q0:q1,:] += lib.einsum('dlia,jlbd->ijab', tmp, t2[:,:,:,p0:p1]).conj()
+        pvOOv = pvoOV = tau = None
+        time1 = log.timer_debug1('rdm intermediates pass2 [%d:%d]'%(p0, p1), *time1)
+    h5fobj['dovov'] = goovv.transpose(0,2,1,3) * 2 - goovv.transpose(1,2,0,3)
+    goovv = goooo = None
+
+    max_memory = max(0, mycc.max_memory - lib.current_memory()[0])
+    unit = max(nocc**2*nvir*2+nocc*nvir**2*3,
+               nvir**3*2+nocc*nvir**2*2+nocc**2*nvir*2)
+    blksize = min(nvir, max(ccsd.BLKMIN, int(max_memory*.9e6/8/unit)))
+    iobuflen = int(256e6/8/blksize)
+    log.debug1('rdm intermediates pass 3: block size = %d, nvir = %d in %d blocks',
+               blksize, nocc, int((nvir+blksize-1)/blksize))
+    dovvv = h5fobj.create_dataset('dovvv', (nocc,nvir,nvir,nvir), dtype,
+                                  chunks=(nocc,min(nocc,nvir),1,nvir))
+    time1 = time.clock(), time.time()
+    for istep, (p0, p1) in enumerate(lib.prange(0, nvir, blksize)):
+        l2tmp = l2[:,:,p0:p1]
+        gvvvv = lib.einsum('ijab,ijcd->abcd', l2tmp, t2)
+        jabc = lib.einsum('ijab,ic->jabc', l2tmp, t1)
+        gvvvv += lib.einsum('jabc,jd->abcd', jabc, t1)
+        l2tmp = jabc = None
+
+        if compress_vvvv:
+# symmetrize dvvvv because it does not affect the results of ccsd_grad
+# dvvvv = gvvvv.transpose(0,2,1,3)-gvvvv.transpose(0,3,1,2)*.5
+# dvvvv = (dvvvv+dvvvv.transpose(0,1,3,2)) * .5
+# dvvvv = (dvvvv+dvvvv.transpose(1,0,2,3)) * .5
+# now dvvvv == dvvvv.transpose(0,1,3,2) == dvvvv.transpose(1,0,3,2)
+            tmp = numpy.empty((nvir,nvir,nvir))
+            tmpvvvv = numpy.empty((p1-p0,nvir,nvir_pair))
+            for i in range(p1-p0):
+                vvv = gvvvv[i].conj().transpose(1,0,2)
+                tmp[:] = vvv - vvv.transpose(2,1,0)*.5
+                lib.pack_tril(tmp+tmp.transpose(0,2,1), out=tmpvvvv[i])
+            # tril of (dvvvv[p0:p1,p0:p1]+dvvvv[p0:p1,p0:p1].T)
+            for i in range(p0, p1):
+                for j in range(p0, i):
+                    tmpvvvv[i-p0,j] += tmpvvvv[j-p0,i]
+                tmpvvvv[i-p0,i] *= 2
+            for i in range(p1, nvir):
+                off = i * (i+1) // 2
+                dvvvv[off+p0:off+p1] = tmpvvvv[:,i]
+            for i in range(p0, p1):
+                off = i * (i+1) // 2
+                if p0 > 0:
+                    tmpvvvv[i-p0,:p0] += dvvvv[off:off+p0]
+                dvvvv[off:off+i+1] = tmpvvvv[i-p0,:i+1] * .25
+            tmp = tmpvvvv = None
+        else:
+            for i in range(p0, p1):
+                vvv = gvvvv[i-p0].conj().transpose(1,0,2)
+                dvvvv[i] = vvv - vvv.transpose(2,1,0)*.5
+
+        gvovv = lib.einsum('adbc,id->aibc', gvvvv, -t1)
+        gvvvv = None
+
+        gvovv += lib.einsum('akic,kb->aibc', fswap['mvoOV'][p0:p1], t1)
+        gvovv -= lib.einsum('akib,kc->aibc', fswap['mvOOv'][p0:p1], t1)
+
+        gvovv += lib.einsum('ja,jibc->aibc', l1[:,p0:p1], t2)
+        gvovv += lib.einsum('ja,jb,ic->aibc', l1[:,p0:p1], t1, t1)
+        gvovv += numpy.einsum('ba,ic->aibc', mvv[:,p0:p1]*.5, t1)
+        gvovv = gvovv.conj()
+        gvovv += lib.einsum('ja,jibc->aibc', t1[:,p0:p1], l2)
+
+        dovvv[:,:,p0:p1] = gvovv.transpose(1,3,0,2)*2 - gvovv.transpose(1,2,0,3)
+        gvvov = None
+        time1 = log.timer_debug1('rdm intermediates pass3 [%d:%d]'%(p0, p1), *time1)
+
+    fswap = None
+    dvvov = None
+    return (h5fobj['dovov'], h5fobj['dvvvv'], h5fobj['doooo'], h5fobj['doovv'],
+            h5fobj['dovvo'], dvvov          , h5fobj['dovvv'], h5fobj['dooov'])
+
+def make_rdm1(mycc, t1, t2, l1, l2, ao_repr=False):
+    '''
+    Spin-traced one-particle density matrix in MO basis (the occupied-virtual
+    blocks from the orbital response contribution are not included).
+
+    dm1[p,q] = <q_alpha^\dagger p_alpha> + <q_beta^\dagger p_beta>
+
+    The convention of 1-pdm is based on McWeeney's book, Eq (5.4.20).
+    The contraction between 1-particle Hamiltonian and rdm1 is
+    E = einsum('pq,qp', h1, rdm1)
+    '''
+    d1 = _gamma1_intermediates(mycc, t1, t2, l1, l2)
+    return _make_rdm1(mycc, d1, with_frozen=True, ao_repr=ao_repr)
+
+def make_rdm2(mycc, t1, t2, l1, l2, ao_repr=False):
+    r'''
+    Spin-traced two-particle density matrix in MO basis
+
+    dm2[p,q,r,s] = \sum_{sigma,tau} <p_sigma^\dagger r_tau^\dagger s_tau q_sigma>
+
+    Note the contraction between ERIs (in Chemist's notation) and rdm2 is
+    E = einsum('pqrs,pqrs', eri, rdm2)
+    '''
+    d1 = _gamma1_intermediates(mycc, t1, t2, l1, l2)
+    f = lib.H5TmpFile()
+    d2 = _gamma2_outcore(mycc, t1, t2, l1, l2, f, False)
+    return _make_rdm2(mycc, d1, d2, with_dm1=True, with_frozen=True,
+                      ao_repr=ao_repr)
+
+def _make_rdm1(mycc, d1, with_frozen=True, ao_repr=False):
+    '''dm1[p,q] = <q_alpha^\dagger p_alpha> + <q_beta^\dagger p_beta>
+
+    The convention of 1-pdm is based on McWeeney's book, Eq (5.4.20).
+    The contraction between 1-particle Hamiltonian and rdm1 is
+    E = einsum('pq,qp', h1, rdm1)
+    '''
+    doo, dov, dvo, dvv = d1
+    nocc, nvir = dov.shape
+    nmo = nocc + nvir
+    dm1 = numpy.empty((nmo,nmo), dtype=doo.dtype)
+    dm1[:nocc,:nocc] = doo + doo.conj().T
+    dm1[:nocc,nocc:] = dov + dvo.conj().T
+    dm1[nocc:,:nocc] = dm1[:nocc,nocc:].conj().T
+    dm1[nocc:,nocc:] = dvv + dvv.conj().T
+    dm1[numpy.diag_indices(nocc)] += 2
+
+    if with_frozen and not (mycc.frozen is 0 or mycc.frozen is None):
+        nmo = mycc.mo_occ.size
+        nocc = numpy.count_nonzero(mycc.mo_occ > 0)
+        rdm1 = numpy.zeros((nmo,nmo), dtype=dm1.dtype)
+        rdm1[numpy.diag_indices(nocc)] = 2
+        moidx = numpy.where(mycc.get_frozen_mask())[0]
+        rdm1[moidx[:,None],moidx] = dm1
+        dm1 = rdm1
+
+    if ao_repr:
+        mo = mycc.mo_coeff
+        dm1 = lib.einsum('pi,ij,qj->pq', mo, dm1, mo.conj())
+    return dm1
+
+# Note vvvv part of 2pdm have been symmetrized.  It does not correspond to
+# vvvv part of CI 2pdm
+def _make_rdm2(mycc, d1, d2, with_dm1=True, with_frozen=True, ao_repr=False):
+    r'''
+    dm2[p,q,r,s] = \sum_{sigma,tau} <p_sigma^\dagger r_tau^\dagger s_tau q_sigma>
+
+    Note the contraction between ERIs (in Chemist's notation) and rdm2 is
+    E = einsum('pqrs,pqrs', eri, rdm2)
+    '''
+    dovov, dvvvv, doooo, doovv, dovvo, dvvov, dovvv, dooov = d2
+    nocc, nvir = dovov.shape[:2]
+    nmo = nocc + nvir
+
+    h5f = lib.H5TmpFile()
+    dm2 = h5f.create_dataset("dm2", (nmo,nmo,nmo,nmo), dtype=doovv.dtype)
+
+    dovov = numpy.asarray(dovov)
+    dm2[:nocc,nocc:,:nocc,nocc:] = dovov
+    dm2[:nocc,nocc:,:nocc,nocc:]+= dovov.transpose(2,3,0,1)
+    dm2[nocc:,:nocc,nocc:,:nocc] = dm2[:nocc,nocc:,:nocc,nocc:].transpose(1,0,3,2).conj()
+    dovov = None
+
+    doovv = numpy.asarray(doovv)
+    dm2[:nocc,:nocc,nocc:,nocc:] = doovv
+    dm2[:nocc,:nocc,nocc:,nocc:]+= doovv.transpose(1,0,3,2).conj()
+    dm2[nocc:,nocc:,:nocc,:nocc] = dm2[:nocc,:nocc,nocc:,nocc:].transpose(2,3,0,1)
+    doovv = None
+
+    dovvo = numpy.asarray(dovvo)
+    dm2[:nocc,nocc:,nocc:,:nocc] = dovvo
+    dm2[:nocc,nocc:,nocc:,:nocc]+= dovvo.transpose(3,2,1,0).conj()
+    dm2[nocc:,:nocc,:nocc,nocc:] = dm2[:nocc,nocc:,nocc:,:nocc].transpose(1,0,3,2).conj()
+    dovvo = None
+
+    max_memory = max(0, mycc.max_memory - lib.current_memory()[0])
+    unit = nvir**3
+
+    if len(dvvvv.shape) == 2:
+# To handle the case of compressed vvvv, which is used in nuclear gradients
+        dvvvv = ao2mo.restore(1, dvvvv, nvir)
+        dm2[nocc:,nocc:,nocc:,nocc:] = dvvvv
+        dm2[nocc:,nocc:,nocc:,nocc:]*= 4
+    else:
+        blksize = min(nvir, max(ccsd.BLKMIN, int(max_memory*.9e6/8/unit)))
+        for istep, (p0, p1) in enumerate(lib.prange(0, nvir, blksize)):
+            dm2[nocc:,nocc:,nocc:,nocc+p0:nocc+p1] = dvvvv[:,:,:,p0:p1]
+            dm2[nocc:,nocc:,nocc:,nocc+p0:nocc+p1]+= dvvvv[:,:,p0:p1,:].transpose(1,0,3,2).conj()
+            dm2[nocc:,nocc:,nocc:,nocc+p0:nocc+p1]*= 2
+    dvvvv = None
+
+    doooo = numpy.asarray(doooo)
+    dm2[:nocc,:nocc,:nocc,:nocc] = doooo
+    dm2[:nocc,:nocc,:nocc,:nocc]+= doooo.transpose(1,0,3,2).conj()
+    dm2[:nocc,:nocc,:nocc,:nocc]*= 2
+    doooo = None
+
+    dovvv = numpy.asarray(dovvv)
+    dm2[:nocc,nocc:,nocc:,nocc:] = dovvv
+    dm2[nocc:,nocc:,:nocc,nocc:] = dovvv.transpose(2,3,0,1)
+    dm2[nocc:,nocc:,nocc:,:nocc] = dovvv.transpose(3,2,1,0).conj()
+    dm2[nocc:,:nocc,nocc:,nocc:] = dovvv.transpose(1,0,3,2).conj()
+    dovvv = None
+
+    dooov = numpy.asarray(dooov)
+    dm2[:nocc,:nocc,:nocc,nocc:] = dooov
+    dm2[:nocc,nocc:,:nocc,:nocc] = dooov.transpose(2,3,0,1)
+    dm2[:nocc,:nocc,nocc:,:nocc] = dooov.transpose(1,0,3,2).conj()
+    dm2[nocc:,:nocc,:nocc,:nocc] = dooov.transpose(3,2,1,0).conj()
+
+    if with_frozen and not (mycc.frozen is 0 or mycc.frozen is None):
+        nmo, nmo0 = mycc.mo_occ.size, nmo
+        nocc = numpy.count_nonzero(mycc.mo_occ > 0)
+        rdm2 = numpy.zeros((nmo,nmo,nmo,nmo), dtype=dm2.dtype)
+        moidx = numpy.where(mycc.get_frozen_mask())[0]
+        idx = (moidx.reshape(-1,1) * nmo + moidx).ravel()
+        lib.takebak_2d(rdm2.reshape(nmo**2,nmo**2),
+                       dm2.reshape(nmo0**2,nmo0**2), idx, idx)
+        dm2 = rdm2
+
+    if with_dm1:
+        dm1 = _make_rdm1(mycc, d1, with_frozen)
+        dm1[numpy.diag_indices(nocc)] -= 2
+
+        for i in range(nocc):
+            dm2[i,i,:,:] += dm1 * 2
+            dm2[:,:,i,i] += dm1 * 2
+            dm2[:,i,i,:] -= dm1
+            dm2[i,:,:,i] -= dm1.T
+
+        for i in range(nocc):
+            for j in range(nocc):
+                dm2[i,i,j,j] += 4
+                dm2[i,j,j,i] -= 2
+
+    # dm2 was computed as dm2[p,q,r,s] = < p^\dagger r^\dagger s q > in the
+    # above. Transposing it so that it be contracted with ERIs (in Chemist's
+    # notation):
+    #   E = einsum('pqrs,pqrs', eri, rdm2)
+    # dm2 = dm2.transpose(1,0,3,2)
+
+    #if ao_repr:
+    #    dm2 = _rdm2_mo2ao(dm2.transpose(1,0,3,2), mycc.mo_coeff)
+    return h5f
+
+
+def _rdm2_mo2ao(dm2, mo):
+    mo_C = mo.conj()
+    return lib.einsum('ijkl,pi,qj,rk,sl->pqrs', dm2, mo, mo_C, mo, mo_C)
+
+
+if __name__ == '__main__':
+    from functools import reduce
+    from pyscf import gto
+    from pyscf import scf
+    from pyscf.cc import ccsd
+    from pyscf import ao2mo
+
+    mol = gto.M()
+    mf = scf.RHF(mol)
+    mcc = ccsd.CCSD(mf)
+
+    numpy.random.seed(2)
+    nocc = 5
+    nmo = 12
+    nvir = nmo - nocc
+    eri0 = numpy.random.random((nmo,nmo,nmo,nmo))
+    eri0 = ao2mo.restore(1, ao2mo.restore(8, eri0, nmo), nmo)
+    fock0 = numpy.random.random((nmo,nmo))
+    fock0 = fock0 + fock0.T + numpy.diag(range(nmo))*2
+    t1 = numpy.random.random((nocc,nvir))
+    t2 = numpy.random.random((nocc,nocc,nvir,nvir))
+    t2 = t2 + t2.transpose(1,0,3,2)
+    l1 = numpy.random.random((nocc,nvir))
+    l2 = numpy.random.random((nocc,nocc,nvir,nvir))
+    l2 = l2 + l2.transpose(1,0,3,2)
+    h1 = fock0 - (numpy.einsum('kkpq->pq', eri0[:nocc,:nocc])*2
+                - numpy.einsum('pkkq->pq', eri0[:,:nocc,:nocc]))
+
+    eris = lambda:None
+    eris.oooo = eri0[:nocc,:nocc,:nocc,:nocc].copy()
+    eris.ooov = eri0[:nocc,:nocc,:nocc,nocc:].copy()
+    eris.ovoo = eri0[:nocc,nocc:,:nocc,:nocc].copy()
+    eris.oovv = eri0[:nocc,:nocc,nocc:,nocc:].copy()
+    eris.ovov = eri0[:nocc,nocc:,:nocc,nocc:].copy()
+    eris.ovvo = eri0[:nocc,nocc:,nocc:,:nocc].copy()
+    eris.ovvv = eri0[:nocc,nocc:,nocc:,nocc:].copy()
+    eris.vvvv = eri0[nocc:,nocc:,nocc:,nocc:].copy()
+    eris.fock = fock0
+
+    doo, dov, dvo, dvv = _gamma1_intermediates(mcc, t1, t2, l1, l2)
+    print((numpy.einsum('ij,ij', doo, fock0[:nocc,:nocc]))*2+20166.329861034799)
+    print((numpy.einsum('ab,ab', dvv, fock0[nocc:,nocc:]))*2-58078.964019246778)
+    print((numpy.einsum('ai,ia', dvo, fock0[:nocc,nocc:]))*2+74994.356886784764)
+    print((numpy.einsum('ia,ai', dov, fock0[nocc:,:nocc]))*2-34.010188025702391)
+
+    fdm2 = lib.H5TmpFile()
+    dovov, dvvvv, doooo, doovv, dovvo, dvvov, dovvv, dooov = \
+            _gamma2_outcore(mcc, t1, t2, l1, l2, fdm2, True)
+    print('dovov', lib.finger(numpy.array(dovov)) - -14384.907042073517)
+    print('dvvvv', lib.finger(numpy.array(dvvvv)) - -25.374007033024839)
+    print('doooo', lib.finger(numpy.array(doooo)) -  60.114594698129963)
+    print('doovv', lib.finger(numpy.array(doovv)) - -79.176348067958401)
+    print('dovvo', lib.finger(numpy.array(dovvo)) -   9.864134457251815)
+    print('dovvv', lib.finger(numpy.array(dovvv)) - -421.90333700061342)
+    print('dooov', lib.finger(numpy.array(dooov)) - -592.66863759586136)
+    fdm2 = None
+
+    dovov, dvvvv, doooo, doovv, dovvo, dvvov, dovvv, dooov = \
+            _gamma2_intermediates(mcc, t1, t2, l1, l2)
+    print('dovov', lib.finger(numpy.array(dovov)) - -14384.907042073517)
+    print('dvvvv', lib.finger(numpy.array(dvvvv)) -  45.872344902116758)
+    print('doooo', lib.finger(numpy.array(doooo)) -  60.114594698129963)
+    print('doovv', lib.finger(numpy.array(doovv)) - -79.176348067958401)
+    print('dovvo', lib.finger(numpy.array(dovvo)) -   9.864134457251815)
+    print('dovvv', lib.finger(numpy.array(dovvv)) - -421.90333700061342)
+    print('dooov', lib.finger(numpy.array(dooov)) - -592.66863759586136)
+
+    print('doooo',numpy.einsum('kilj,kilj', doooo, eris.oooo)*2-15939.9007625418)
+    print('dvvvv',numpy.einsum('acbd,acbd', dvvvv, eris.vvvv)*2-37581.823919588 )
+    print('dooov',numpy.einsum('jkia,jkia', dooov, eris.ooov)*2-128470.009687716)
+    print('dovvv',numpy.einsum('icba,icba', dovvv, eris.ovvv)*2+166794.225195056)
+    print('dovov',numpy.einsum('iajb,iajb', dovov, eris.ovov)*2+719279.812916893)
+    print('dovvo',numpy.einsum('jbai,jbia', dovvo, eris.ovov)*2
+                 +numpy.einsum('jiab,jiba', doovv, eris.oovv)*2+53634.0012286654)
+
+    dm1 = make_rdm1(mcc, t1, t2, l1, l2)
+    dm2 = make_rdm2(mcc, t1, t2, l1, l2)
+    e2 =(numpy.einsum('ijkl,ijkl', doooo, eris.oooo)*2
+        +numpy.einsum('acbd,acbd', dvvvv, eris.vvvv)*2
+        +numpy.einsum('jkia,jkia', dooov, eris.ooov)*2
+        +numpy.einsum('icba,icba', dovvv, eris.ovvv)*2
+        +numpy.einsum('iajb,iajb', dovov, eris.ovov)*2
+        +numpy.einsum('jbai,jbia', dovvo, eris.ovov)*2
+        +numpy.einsum('ijab,ijab', doovv, eris.oovv)*2
+        +numpy.einsum('ij,ij', doo, fock0[:nocc,:nocc])*2
+        +numpy.einsum('ia,ia', dov, fock0[:nocc,nocc:])*2
+        +numpy.einsum('ai,ai', dvo, fock0[nocc:,:nocc])*2
+        +numpy.einsum('ab,ab', dvv, fock0[nocc:,nocc:])*2
+        +fock0[:nocc].trace()*2
+        -numpy.einsum('kkpq->pq', eri0[:nocc,:nocc,:nocc,:nocc]).trace()*2
+        +numpy.einsum('pkkq->pq', eri0[:nocc,:nocc,:nocc,:nocc]).trace())
+    print(e2+794721.197459942)
+    print(numpy.einsum('pqrs,pqrs', dm2, eri0)*.5 +
+          numpy.einsum('pq,qp', dm1, h1) - e2)
+
+    print(numpy.allclose(dm2, dm2.transpose(1,0,3,2)))
+    print(numpy.allclose(dm2, dm2.transpose(2,3,0,1)))
+
+    d1 = numpy.einsum('kkpq->qp', dm2) / 9
+    print(numpy.allclose(d1, dm1))
+
+    mol = gto.Mole()
+    mol.atom = [
+        [8 , (0. , 0.     , 0.)],
+        [1 , (0. , -0.757 , 0.587)],
+        [1 , (0. , 0.757  , 0.587)]]
+    mol.basis = '631g'
+    mol.build()
+    mf = scf.RHF(mol).run()
+
+    mycc = ccsd.CCSD(mf)
+    mycc.frozen = 2
+    ecc, t1, t2 = mycc.kernel()
+    l1, l2 = mycc.solve_lambda()
+    dm1 = make_rdm1(mycc, t1, t2, l1, l2)
+    dm2 = make_rdm2(mycc, t1, t2, l1, l2)
+    nmo = mf.mo_coeff.shape[1]
+    eri = ao2mo.kernel(mf._eri, mf.mo_coeff, compact=False).reshape([nmo]*4)
+    hcore = mf.get_hcore()
+    h1 = reduce(numpy.dot, (mf.mo_coeff.T, hcore, mf.mo_coeff))
+    e1 = numpy.einsum('ij,ji', h1, dm1)
+    e1+= numpy.einsum('ijkl,ijkl', eri, dm2) * .5
+    e1+= mol.energy_nuc()
+    print(e1 - mycc.e_tot)

--- a/mldftdat/lowmem_analyzers.py
+++ b/mldftdat/lowmem_analyzers.py
@@ -1,0 +1,461 @@
+from pyscf import scf, dft, gto, ao2mo, df, lib, fci, cc
+from pyscf.dft.numint import eval_ao, eval_rho
+from pyscf.dft.gen_grid import Grids
+from pyscf.pbc.tools.pyscf_ase import atoms_from_ase
+from mldftdat.pyscf_utils import *
+import numpy as np
+from abc import ABC, abstractmethod, abstractproperty
+from io import BytesIO
+import psutil
+
+
+CALC_TYPES = {
+    'RHF'   : scf.hf.RHF,
+    'UHF'   : scf.uhf.UHF,
+    'RKS'   : dft.rks.RKS,
+    'UKS'   : dft.uks.UKS,
+    'CCSD'  : cc.ccsd.CCSD,
+    'UCCSD' : cc.uccsd.UCCSD
+}
+
+def recursive_remove_none(obj):
+    if type(obj) == dict:
+        return {k: recursive_remove_none(v) for k, v in obj.items() if v is not None}
+    else:
+        return obj
+
+
+class ElectronAnalyzer(ABC):
+
+    calc_class = None
+    calc_type = None
+
+    def __init__(self, calc, require_converged=True, max_mem=None):
+        # max_mem in MB
+        if not isinstance(calc, self.calc_class):
+            raise ValueError('Calculation must be instance of {}.'.format(self.calc_class))
+        if calc.e_tot is None:
+            raise ValueError('{} calculation must be complete.'.format(self.calc_type))
+        if require_converged and not calc.converged:
+            raise ValueError('{} calculation must be converged.'.format(self.calc_type))
+        self.calc = calc
+        self.mol = calc.mol
+        self.conv_tol = self.calc.conv_tol
+        self.converged = calc.converged
+        self.max_mem = max_mem
+        self.post_process()
+
+    def as_dict(self):
+        calc_props = {
+            'conv_tol' : self.conv_tol,
+            'converged' : self.converged,
+            'e_tot' : self.e_tot,
+            'mo_coeff' : self.mo_coeff,
+            'mo_occ' : self.mo_occ,
+        }
+        data = {
+            'coords' : self.grid.coords,
+            'weights' : self.grid.weights,
+            'ha_total' : self.ha_total,
+            'fx_total' : self.fx_total,
+            'ha_energy_density' : self.ha_energy_density,
+            'fx_energy_density' : self.fx_energy_density,
+            'xc_energy_density' : self.xc_energy_density,
+            'ee_energy_density' : self.ee_energy_density,
+            'rho_data' : self.rho_data,
+            'tau_data' : self.tau_data
+        }
+        return {
+            'mol' : gto.mole.pack(self.mol),
+            'calc_type' : self.calc_type,
+            'calc' : calc_props,
+            'data' : data
+        }
+
+    def dump(self, fname):
+        h5dict = recursive_remove_none(self.as_dict())
+        lib.chkfile.dump(fname, 'analyzer', h5dict)
+
+    @classmethod
+    def from_dict(cls, analyzer_dict, max_mem = None):
+        if analyzer_dict['calc_type'] != cls.calc_type:
+            raise ValueError('Dict is from wrong type of calc, {} vs {}!'.format(
+                                analyzer_dict['calc_type'], cls.calc_type))
+        mol = gto.mole.unpack(analyzer_dict['mol'])
+        mol.build()
+        calc = cls.calc_class(mol)
+        calc.__dict__.update(analyzer_dict['calc'])
+        analyzer = cls(calc, require_converged = False, max_mem = max_mem)
+        analyzer_dict['data'].pop('coords')
+        analyzer_dict['data'].pop('weights')
+        analyzer.__dict__.update(analyzer_dict['data'])
+        return analyzer
+
+    @classmethod
+    def load(cls, fname):
+        analyzer_dict = lib.chkfile.load(fname, 'analyzer')
+        return cls.from_dict(analyzer_dict)
+
+    def assign_num_chunks(self, ao_vals_shape, ao_vals_dtype):
+        if self.max_mem == None:
+            self.num_chunks = 1
+            return self.num_chunks
+
+        if ao_vals_dtype == np.float32:
+            nbytes = 4
+        elif ao_vals_dtype == np.float64:
+            nbytes = 8
+        else:
+            raise ValueError('Wrong dtype for ao_vals')
+        num_mbytes = nbytes * ao_vals_shape[0] * ao_vals_shape[1]**2 // 1000000
+        self.num_chunks = int(num_mbytes // self.max_mem) + 1
+        return self.num_chunks
+
+    def post_process(self):
+        # The child post process function must set up the RDMs
+        self.grid = get_grid(self.mol)
+
+        self.e_tot = self.calc.e_tot
+        self.mo_coeff = self.calc.mo_coeff
+        self.mo_occ = self.calc.mo_occ
+        ###self.mo_energy = self.calc.mo_energy
+        self.ao_vals = get_ao_vals(self.mol, self.grid.coords)
+        self.mo_vals = get_mo_vals(self.ao_vals, self.mo_coeff)
+
+        self.assign_num_chunks(self.ao_vals.shape, self.ao_vals.dtype)
+        print("NUMBER OF CHUNKS", self.num_chunks, self.ao_vals.dtype, psutil.virtual_memory().available // 1e6)
+
+        self.ao_vele_mat = get_vele_mat_generator(self.mol, self.grid.coords,
+                                            self.num_chunks, self.ao_vals)
+
+        print("MEM NOW", psutil.virtual_memory().available // 1e6)
+
+        self.rdm1 = None
+        self.rdm2 = None
+        self.ao_data = None
+        self.rho_data = None
+        self.tau_data = None
+
+        self.ha_total = None
+        self.fx_total = None
+        self.ee_total = None
+        self.ha_energy_density = None
+        self.fx_energy_density = None
+        self.xc_energy_density = None
+        self.ee_energy_density = None
+
+    def get_ao_rho_data(self):
+        if self.rho_data is None or self.tau_data is None:
+            ao_data, self.rho_data = get_mgga_data(
+                                        self.mol, self.grid, self.rdm1)
+            self.tau_data = get_tau_and_grad(self.mol, self.grid,
+                                            self.rdm1, ao_data)
+        return self.rho_data, self.tau_data
+
+    def perform_full_analysis(self):
+        self.get_ao_rho_data()
+        self.get_ha_energy_density()
+        self.get_ee_energy_density()
+
+
+class RHFAnalyzer(ElectronAnalyzer):
+
+    calc_class = scf.hf.RHF
+    calc_type = 'RHF'
+
+    def as_dict(self):
+        analyzer_dict = super(RHFAnalyzer, self).as_dict()
+        analyzer_dict['calc']['mo_energy'] = self.mo_energy
+        return analyzer_dict
+
+    def post_process(self):
+        super(RHFAnalyzer, self).post_process()
+        self.rdm1 = np.array(self.calc.make_rdm1())
+        self.mo_energy = self.calc.mo_energy
+        self.jmat, self.kmat = scf.hf.get_jk(self.mol, self.rdm1)
+        self.ha_total, self.fx_total = get_hf_coul_ex_total2(self.rdm1,
+                                                    self.jmat, self.kmat)
+        self.mo_vele_mat = get_vele_mat_generator(self.mol, self.grid.coords,
+                                            self.num_chunks, self.mo_vals,
+                                            self.mo_coeff)
+
+    def get_ha_energy_density(self):
+        if self.ha_energy_density is None:
+            self.ha_energy_density = get_ha_energy_density2(
+                                    self.mol, self.rdm1,
+                                    self.ao_vele_mat, self.ao_vals
+                                    )
+        return self.ha_energy_density
+
+    def get_fx_energy_density(self):
+        if self.fx_energy_density is None:
+            self.fx_energy_density = get_fx_energy_density2(
+                                    self.mol, self.mo_occ,
+                                    self.mo_vele_mat, self.mo_vals
+                                    )
+        return self.fx_energy_density
+
+    def get_ee_energy_density(self):
+        if self.ee_energy_density is None:
+            self.ee_energy_density = self.get_ha_energy_density()\
+                                     + self.get_fx_energy_density()
+        return self.ee_energy_density
+
+    def _get_rdm2(self):
+        if self.rdm2 is None:
+            self.rdm2 = make_rdm2_from_rdm1(self.rdm1)
+        return self.rdm2
+
+    def _get_ee_energy_density_slow(self):
+        rdm2 = self._get_rdm2()
+        return get_ee_energy_density2(self.mol, self.rdm2,
+                                        self.ao_vele_mat, self.ao_vals)
+
+
+class UHFAnalyzer(ElectronAnalyzer):
+
+    calc_class = scf.uhf.UHF
+    calc_type = 'UHF'
+
+    def as_dict(self):
+        analyzer_dict = super(UHFAnalyzer, self).as_dict()
+        analyzer_dict['calc']['mo_energy'] = self.mo_energy
+        analyzer_dict['data']['fx_energy_density_u'] = self.fx_energy_density_u
+        analyzer_dict['data']['fx_energy_density_d'] = self.fx_energy_density_d
+        return analyzer_dict
+
+    def post_process(self):
+        super(UHFAnalyzer, self).post_process()
+        self.rdm1 = np.array(self.calc.make_rdm1())
+        self.mo_energy = self.calc.mo_energy
+        self.fx_energy_density_u = None
+        self.fx_energy_density_d = None
+        self.jmat, self.kmat = scf.hf.get_jk(self.mol, self.rdm1)
+        self.ha_total, self.fx_total = get_hf_coul_ex_total2(self.rdm1,
+                                                    self.jmat, self.kmat)
+        if self.num_chunks > 1:
+            self.mo_vele_mat = [get_vele_mat_generator(self.mol, self.grid.coords,
+                                                self.num_chunks, self.mo_vals[0],
+                                                self.mo_coeff[0]),\
+                                get_vele_mat_generator(self.mol, self.grid.coords,
+                                                self.num_chunks, self.mo_vals[1],
+                                                self.mo_coeff[1])]
+        else:
+            self.mo_vele_mat = get_mo_vele_mat(self.ao_vele_mat, self.mo_coeff)
+
+    def get_ha_energy_density(self):
+        if self.ha_energy_density is None:
+            self.ha_energy_density = get_ha_energy_density2(
+                                    self.mol, np.sum(self.rdm1, axis=0),
+                                    self.ao_vele_mat, self.ao_vals
+                                    )
+        return self.ha_energy_density
+
+    def get_fx_energy_density(self):
+        if self.fx_energy_density is None:
+            self.fx_energy_density_u = 0.5 * get_fx_energy_density2(
+                                        self.mol, 2 * self.mo_occ[0],
+                                        self.mo_vele_mat[0], self.mo_vals[0]
+                                        )
+            self.fx_energy_density_d = 0.5 * get_fx_energy_density2(
+                                        self.mol, 2 * self.mo_occ[1],
+                                        self.mo_vele_mat[1], self.mo_vals[1]
+                                        )
+            self.fx_energy_density = self.fx_energy_density_u + self.fx_energy_density_d
+        return self.fx_energy_density
+
+    def get_ee_energy_density(self):
+        if self.ee_energy_density is None:
+            self.ee_energy_density = self.get_ha_energy_density()\
+                                     + self.get_fx_energy_density()
+        return self.ee_energy_density
+
+    def _get_rdm2(self):
+        if self.rdm2 is None:
+            self.rdm2 = make_rdm2_from_rdm1_unrestricted(self.rdm1)
+        return self.rdm2
+
+    def _get_ee_energy_density_slow(self):
+        rdm2 = self._get_rdm2()
+        euu = get_ee_energy_density2(self.mol, self.rdm2[0],
+                                    self.ao_vele_mat, self.ao_vals)
+        eud = get_ee_energy_density2(self.mol, self.rdm2[1],
+                                    self.ao_vele_mat, self.ao_vals)
+        edd = get_ee_energy_density2(self.mol, self.rdm2[2],
+                                    self.ao_vele_mat, self.ao_vals)
+        return euu + 2 * eud + edd
+
+
+class RKSAnalyzer(RHFAnalyzer):
+
+    def __init__(self, calc, require_converged=True, max_mem=None):
+        if type(calc) != dft.rks.RKS:
+            raise ValueError('Calculation must be RKS.')
+        self.dft = calc
+        hf = scf.RHF(self.dft.mol)
+        hf.e_tot = self.dft.e_tot
+        hf.mo_coeff = self.dft.mo_coeff
+        hf.mo_occ = self.dft.mo_occ
+        hf.mo_energy = self.dft.mo_energy
+        hf.converged = self.dft.converged
+        super(RKSAnalyzer, self).__init__(hf, require_converged, max_mem)
+
+
+class UKSAnalyzer(UHFAnalyzer):
+
+    def __init__(self, calc, require_converged=True, max_mem=None):
+        if type(calc) != dft.uks.UKS:
+            raise ValueError('Calculation must be UKS.')
+        self.dft = calc
+        hf = scf.UHF(self.dft.mol)
+        hf.e_tot = self.dft.e_tot
+        hf.mo_coeff = self.dft.mo_coeff
+        hf.mo_occ = self.dft.mo_occ
+        hf.mo_energy = self.dft.mo_energy
+        hf.converged = self.dft.converged
+        super(UKSAnalyzer, self).__init__(hf, require_converged, max_mem)
+
+
+class CCSDAnalyzer(ElectronAnalyzer):
+
+    calc_class = cc.ccsd.CCSD
+    calc_type = 'CCSD'
+
+    def as_dict(self):
+        analyzer_dict = super(CCSDAnalyzer, self).as_dict()
+        analyzer_dict['calc']['t1'] = self.calc.t1
+        analyzer_dict['calc']['t2'] = self.calc.t2
+        analyzer_dict['calc']['l1'] = self.calc.l1
+        analyzer_dict['calc']['l2'] = self.calc.l2
+        analyzer_dict['calc']['e_corr'] = self.calc.e_corr
+        analyzer_dict['data']['ee_total'] = self.ee_total
+        return analyzer_dict
+
+    @classmethod
+    def from_dict(cls, analyzer_dict, max_mem = None):
+        if analyzer_dict['calc_type'] != cls.calc_type:
+            raise ValueError('Dict is from wrong type of calc, {} vs {}!'.format(
+                                analyzer_dict['calc_type'], cls.calc_type))
+        mol = gto.mole.unpack(analyzer_dict['mol'])
+        mol.build()
+        hf = scf.hf.RHF(mol)
+        hf.e_tot = analyzer_dict['calc'].pop('e_tot') - analyzer_dict['calc']['e_corr']
+        calc = cls.calc_class(hf)
+        calc.__dict__.update(analyzer_dict['calc'])
+        analyzer = cls(calc, require_converged = False, max_mem = max_mem)
+        analyzer.__dict__.update(analyzer_dict['data'])
+        return analyzer
+
+    def post_process(self):
+        super(CCSDAnalyzer, self).post_process()
+        self.mo_rdm1 = np.array(self.calc.make_rdm1())
+        self.mo_rdm2 = np.array(self.calc.make_rdm2())
+
+        self.ao_rdm1 = transform_basis_1e(self.mo_rdm1, self.mo_coeff.transpose())
+        self.ao_rdm2 = transform_basis_2e(self.mo_rdm2, self.mo_coeff.transpose())
+        self.eri_mo = transform_basis_2e(self.eri_ao, self.mo_coeff)
+        self.rdm1 = self.ao_rdm1
+        self.rdm2 = self.ao_rdm2
+        self.ee_total = get_ccsd_ee(self.mo_rdm2, self.eri_mo)
+
+        self.jmat, self.kmat = scf.hf.get_jk(self.mol, self.rdm1)
+        self.ha_total, self.fx_total = get_hf_coul_ex_total2(self.rdm1,
+                                                    self.jmat, self.kmat)
+
+    def get_ha_energy_density(self):
+        if self.ha_energy_density is None:
+            self.ha_energy_density = get_ha_energy_density2(
+                                    self.mol, self.ao_rdm1,
+                                    self.ao_vele_mat, self.ao_vals
+                                    )
+        return self.ha_energy_density
+
+    def get_ee_energy_density(self):
+        if self.ee_energy_density is None:
+            self.ee_energy_density = get_ee_energy_density2(
+                                    self.mol, self.ao_rdm2,
+                                    self.ao_vele_mat, self.ao_vals)
+        return self.ee_energy_density
+
+
+class UCCSDAnalyzer(ElectronAnalyzer):
+
+    calc_class = cc.uccsd.UCCSD
+    calc_type = 'UCCSD'
+
+    def as_dict(self):
+        analyzer_dict = super(UCCSDAnalyzer, self).as_dict()
+        analyzer_dict['calc']['t1'] = self.calc.t1
+        analyzer_dict['calc']['t2'] = self.calc.t2
+        analyzer_dict['calc']['l1'] = self.calc.l1
+        analyzer_dict['calc']['l2'] = self.calc.l2
+        analyzer_dict['calc']['e_corr'] = self.calc.e_corr
+
+        analyzer_dict['data']['ee_total'] = self.ee_total
+        analyzer_dict['data']['ee_energy_density_uu'] = self.ee_energy_density_uu
+        analyzer_dict['data']['ee_energy_density_ud'] = self.ee_energy_density_ud
+        analyzer_dict['data']['ee_energy_density_dd'] = self.ee_energy_density_dd
+
+        return analyzer_dict
+
+    @classmethod
+    def from_dict(cls, analyzer_dict, max_mem = None):
+        if analyzer_dict['calc_type'] != cls.calc_type:
+            raise ValueError('Dict is from wrong type of calc, {} vs {}!'.format(
+                                analyzer_dict['calc_type'], cls.calc_type))
+        mol = gto.mole.unpack(analyzer_dict['mol'])
+        mol.build()
+        hf = scf.uhf.UHF(mol)
+        hf.e_tot = analyzer_dict['calc'].pop('e_tot') - analyzer_dict['calc']['e_corr']
+        calc = cls.calc_class(hf)
+        calc.__dict__.update(analyzer_dict['calc'])
+        analyzer = cls(calc, require_converged = False, max_mem = max_mem)
+        analyzer.__dict__.update(analyzer_dict['data'])
+        return analyzer
+
+    def post_process(self):
+        super(UCCSDAnalyzer, self).post_process()
+        self.mo_rdm1 = np.array(self.calc.make_rdm1())
+        self.mo_rdm2 = np.array(self.calc.make_rdm2())
+
+        # These are all three-tuples
+        trans_mo_coeff = np.transpose(self.mo_coeff, axes=(0,2,1))
+        self.ao_rdm1 = transform_basis_1e(self.mo_rdm1, trans_mo_coeff)
+        self.ao_rdm2 = transform_basis_2e(self.mo_rdm2, trans_mo_coeff)
+        eri_ao_lst = [self.eri_ao] * 3
+        self.eri_mo = transform_basis_2e(eri_ao_lst, self.mo_coeff)
+        self.rdm1 = self.ao_rdm1
+        self.rdm2 = self.ao_rdm2
+        self.ee_total = get_ccsd_ee(self.mo_rdm2, self.eri_mo)
+
+        self.jmat, self.kmat = scf.hf.get_jk(self.mol, self.rdm1)
+        self.ha_total, self.fx_total = get_hf_coul_ex_total2(self.rdm1,
+                                                    self.jmat, self.kmat)
+
+        self.ee_energy_density_uu = None
+        self.ee_energy_density_ud = None
+        self.ee_energy_density_dd = None
+
+    def get_ha_energy_density(self):
+        if self.ha_energy_density is None:
+            self.ha_energy_density = get_ha_energy_density2(
+                                    self.mol, np.sum(self.ao_rdm1, axis=0),
+                                    self.ao_vele_mat, self.ao_vals
+                                    )
+        return self.ha_energy_density
+
+    def get_ee_energy_density(self):
+        if self.ee_energy_density is None:
+            self.ee_energy_density_uu = get_ee_energy_density2(
+                                    self.mol, self.ao_rdm2[0],
+                                    self.ao_vele_mat, self.ao_vals)
+            self.ee_energy_density_ud = get_ee_energy_density2(
+                                    self.mol, self.ao_rdm2[1],
+                                    self.ao_vele_mat, self.ao_vals)
+            self.ee_energy_density_dd = get_ee_energy_density2(
+                                    self.mol, self.ao_rdm2[2],
+                                    self.ao_vele_mat, self.ao_vals)
+            self.ee_energy_density = self.ee_energy_density_uu\
+                                    + 2 * self.ee_energy_density_ud\
+                                    + self.ee_energy_density_dd
+        return self.ee_energy_density

--- a/mldftdat/lowmem_analyzers.py
+++ b/mldftdat/lowmem_analyzers.py
@@ -4,7 +4,7 @@ from pyscf.dft.gen_grid import Grids
 from pyscf.pbc.tools.pyscf_ase import atoms_from_ase
 from mldftdat.pyscf_utils import *
 from mldftdat.external import pyscf_ccsd_rdm as ext_ccsd_rdm
-from mldftdat.external import pyscf_uccsd_rdm as ext_uccsd_rdm
+#from mldftdat.external import pyscf_uccsd_rdm as ext_uccsd_rdm
 import numpy as np
 from abc import ABC, abstractmethod, abstractproperty
 from io import BytesIO

--- a/mldftdat/lowmem_analyzers.py
+++ b/mldftdat/lowmem_analyzers.py
@@ -70,7 +70,7 @@ def get_ee_energy_density_outcore(mol, rdm2_file, vele_mat_file, mo_vals,
 def get_ee_energy_density_outcore2(mol, rdm2, vele_mat, orb_vals):
     ee_energy_density = np.array([])
     norb = orb_vals.shape[1]
-    for vele_mat_chunk, orb_vals_chunk in vele_mat():
+    for vele_mat_chunk, orb_vals_chunk in vele_mat(orb_vals):
         num_mbytes = 8 * norb**4 // 1000000
         num_chunks = 5#int(num_mbytes // self.max_mem) + 1
         blksize = norb // num_chunks + 1
@@ -186,7 +186,7 @@ class ElectronAnalyzer(ABC):
         self.assign_num_chunks(self.ao_vals.shape, self.ao_vals.dtype)
 
         self.ao_vele_mat = get_vele_mat_generator(self.mol, self.grid.coords,
-                                            self.num_chunks, self.ao_vals)
+                                                  self.num_chunks)
 
         self.rdm1 = None
         self.rdm2 = None
@@ -234,8 +234,7 @@ class RHFAnalyzer(ElectronAnalyzer):
         self.ha_total, self.fx_total = get_hf_coul_ex_total2(self.rdm1,
                                                     self.jmat, self.kmat)
         self.mo_vele_mat = get_vele_mat_generator(self.mol, self.grid.coords,
-                                            self.num_chunks, self.mo_vals,
-                                            self.mo_coeff)
+                                            self.num_chunks, self.mo_coeff)
 
     def get_ha_energy_density(self):
         if self.ha_energy_density is None:
@@ -282,11 +281,9 @@ class UHFAnalyzer(ElectronAnalyzer):
         self.ha_total, self.fx_total = get_hf_coul_ex_total2(self.rdm1,
                                                     self.jmat, self.kmat)
         self.mo_vele_mat = [get_vele_mat_generator(self.mol, self.grid.coords,
-                                            self.num_chunks, self.mo_vals[0],
-                                            self.mo_coeff[0]),\
+                                            self.num_chunks, self.mo_coeff[0]),\
                             get_vele_mat_generator(self.mol, self.grid.coords,
-                                            self.num_chunks, self.mo_vals[1],
-                                            self.mo_coeff[1])]
+                                            self.num_chunks, self.mo_coeff[1])]
 
     def get_ha_energy_density(self):
         if self.ha_energy_density is None:
@@ -386,8 +383,7 @@ class CCSDAnalyzer(ElectronAnalyzer):
         self.ao_rdm1 = transform_basis_1e(self.mo_rdm1, self.mo_coeff.transpose())
         self.rdm1 = self.ao_rdm1
         self.mo_vele_mat = get_vele_mat_generator(self.mol, self.grid.coords,
-                                            self.num_chunks, self.mo_vals,
-                                            self.mo_coeff)
+                                            self.num_chunks, self.mo_coeff)
         self.ee_total = None
 
         self.jmat, self.kmat = scf.hf.get_jk(self.mol, self.rdm1)
@@ -478,11 +474,9 @@ class UCCSDAnalyzer(ElectronAnalyzer):
                                                     self.jmat, self.kmat)
 
         self.mo_vele_mat = [get_vele_mat_generator(self.mol, self.grid.coords,
-                                            self.num_chunks, self.mo_vals[0],
-                                            self.mo_coeff[0]),\
+                                            self.num_chunks, self.mo_coeff[0]),\
                             get_vele_mat_generator(self.mol, self.grid.coords,
-                                            self.num_chunks, self.mo_vals[1],
-                                            self.mo_coeff[1])]
+                                            self.num_chunks, self.mo_coeff[1])]
 
         self.ee_energy_density_uu = None
         self.ee_energy_density_ud = None
@@ -503,7 +497,7 @@ class UCCSDAnalyzer(ElectronAnalyzer):
                                     self.mo_vele_mat[0], self.mo_vals[0])
             self.ee_energy_density_ud = get_ee_energy_density_outcore2(
                                     self.mol, self.mo_rdm2_file['dm2ab'],
-                                    self.mo_vele_mat[0], self.mo_vals[1])
+                                    self.mo_vele_mat[1], self.mo_vals[0])
             self.ee_energy_density_dd = get_ee_energy_density_outcore2(
                                     self.mol, self.mo_rdm2_file['dm2bb'],
                                     self.mo_vele_mat[1], self.mo_vals[1])

--- a/mldftdat/pyscf_tasks.py
+++ b/mldftdat/pyscf_tasks.py
@@ -8,8 +8,9 @@ from pyscf import scf, dft, cc
 import json
 
 from mldftdat.pyscf_utils import *
-from mldftdat.analyzers import RHFAnalyzer, UHFAnalyzer,\
-        CCSDAnalyzer, UCCSDAnalyzer, RKSAnalyzer, UKSAnalyzer, CALC_TYPES
+from mldftdat.analyzers import CALC_TYPES
+import mldftdat.analyzers
+import mldftdat.lowmem_analyzers
 
 import os, psutil, multiprocessing, time, datetime
 from itertools import product
@@ -237,18 +238,25 @@ class TrainingDataCollector(FiretaskBase):
             'wall_time'  : fw_spec['wall_time']
         }
 
+        if calc.mo_coeff.shape[-1] < 200:
+            print ("USING STD ANALYZER MODULE")
+            analyzer_module = mldftdat.analyzers
+        else:
+            print("USING LOWMEM ANALYZER MODULE")
+            analyzer_module = mldftdat.lowmem_analyzers
+
         if type(calc) == scf.hf.RHF:
-            Analyzer = RHFAnalyzer
+            Analyzer = analyzer_module.RHFAnalyzer
         elif type(calc) == dft.rks.RKS:
-            Analyzer = RHFAnalyzer
+            Analyzer = analyzer_module.RHFAnalyzer
         elif type(calc) == scf.uhf.UHF:
-            Analyzer = UHFAnalyzer
+            Analyzer = analyzer_module.UHFAnalyzer
         elif type(calc) == dft.uks.UKS:
-            Analyzer = UHFAnalyzer
+            Analyzer = analyzer_module.UHFAnalyzer
         elif type(calc) == cc.ccsd.CCSD:
-            Analyzer = CCSDAnalyzer
+            Analyzer = analyzer_module.CCSDAnalyzer
         elif type(calc) == cc.uccsd.UCCSD:
-            Analyzer = UCCSDAnalyzer
+            Analyzer = analyzer_module.UCCSDAnalyzer
         else:
             raise NotImplementedError(
                 'Training data collection not supported for {}'.format(type(calc)))

--- a/mldftdat/pyscf_tasks.py
+++ b/mldftdat/pyscf_tasks.py
@@ -14,8 +14,7 @@ from mldftdat.analyzers import RHFAnalyzer, UHFAnalyzer,\
 import os, psutil, multiprocessing, time, datetime
 from itertools import product
 from mldftdat.workflow_utils import safe_mem_cap_mb, time_func,\
-                                    get_functional_db_name, get_save_dir,\
-                                    load_calc
+                                    get_functional_db_name, get_save_dir
 
 
 @explicit_serialize

--- a/mldftdat/pyscf_utils.py
+++ b/mldftdat/pyscf_utils.py
@@ -341,7 +341,6 @@ def get_ee_energy_density(mol, rdm2, vele_mat, orb_vals):
     rdm2.shape = (shape[0] * shape[1], shape[2] * shape[3])
     vele_mat, shape = vele_mat.view(), vele_mat.shape
     vele_mat.shape = (shape[0], shape[1] * shape[2])
-    print(vele_mat.shape, rdm2.shape)
     vele_tmp = dgemm(1, vele_mat, rdm2, trans_b=True)
     vele_tmp.shape = (shape[0], orb_vals.shape[1], orb_vals.shape[1])
     tmp = np.einsum('pij,pj->pi', vele_tmp, orb_vals)

--- a/mldftdat/pyscf_utils.py
+++ b/mldftdat/pyscf_utils.py
@@ -286,8 +286,8 @@ def get_vele_mat_chunks(mol, points, num_chunks, orb_vals, mo_coeff=None):
             vele_mat_chunk = get_mo_vele_mat(vele_mat_chunk, mo_coeff)
         yield vele_mat_chunk, orb_vals_chunk
 
-def get_vele_mat_generator(mol, points, num_chunks, orb_vals, mo_coeff=None):
-    get_generator = lambda: get_vele_mat_chunks(mol, points,
+def get_vele_mat_generator(mol, points, num_chunks, mo_coeff=None):
+    get_generator = lambda orb_vals: get_vele_mat_chunks(mol, points,
                                 num_chunks, orb_vals, mo_coeff)
     return get_generator
 
@@ -358,7 +358,7 @@ def get_ha_energy_density2(mol, rdm1, vele_mat, ao_vals):
         return get_ha_energy_density(mol, rdm1, vele_mat, ao_vals)
     else:
         ha_energy_density = np.array([])
-        for vele_mat_chunk, orb_vals_chunk in vele_mat():
+        for vele_mat_chunk, orb_vals_chunk in vele_mat(ao_vals):
             ha_energy_density = np.append(ha_energy_density,
                                     get_ha_energy_density(mol, rdm1,
                                         vele_mat_chunk, orb_vals_chunk))
@@ -370,7 +370,7 @@ def get_fx_energy_density2(mol, mo_occ, mo_vele_mat, mo_vals):
         return get_fx_energy_density(mol, mo_occ, mo_vele_mat, mo_vals)
     else:
         fx_energy_density = np.array([])
-        for vele_mat_chunk, orb_vals_chunk in mo_vele_mat():
+        for vele_mat_chunk, orb_vals_chunk in mo_vele_mat(mo_vals):
             fx_energy_density = np.append(fx_energy_density,
                                     get_fx_energy_density(mol, mo_occ,
                                         vele_mat_chunk, orb_vals_chunk))
@@ -381,7 +381,7 @@ def get_ee_energy_density2(mol, rdm2, vele_mat, orb_vals):
         return get_ee_energy_density(mol, rdm2, vele_mat, orb_vals)
     else:
         ee_energy_density = np.array([])
-        for vele_mat_chunk, orb_vals_chunk in vele_mat():
+        for vele_mat_chunk, orb_vals_chunk in vele_mat(orb_vals):
             ee_energy_density = np.append(ee_energy_density,
                                     get_ee_energy_density(mol, rdm2,
                                         vele_mat_chunk, orb_vals_chunk))

--- a/mldftdat/pyscf_utils.py
+++ b/mldftdat/pyscf_utils.py
@@ -328,8 +328,9 @@ def get_ee_energy_density(mol, rdm2, vele_mat, orb_vals):
     rdm2.shape = (shape[0] * shape[1], shape[2] * shape[3])
     vele_mat, shape = vele_mat.view(), vele_mat.shape
     vele_mat.shape = (shape[0], shape[1] * shape[2])
+    print(vele_mat.shape, rdm2.shape)
     vele_tmp = dgemm(1, vele_mat, rdm2, trans_b=True)
-    vele_tmp.shape = (shape[0], shape[1], shape[2])
+    vele_tmp.shape = (shape[0], orb_vals.shape[1], orb_vals.shape[1])
     tmp = np.einsum('pij,pj->pi', vele_tmp, orb_vals)
     Vele = np.einsum('pi,pi->p', tmp, orb_vals)
     return 0.5 * Vele

--- a/mldftdat/tests/test_lowmem_analyzers.py
+++ b/mldftdat/tests/test_lowmem_analyzers.py
@@ -1,0 +1,398 @@
+from pyscf import scf, gto, lib
+from nose import SkipTest
+from nose.tools import nottest
+from nose.plugins.skip import Skip
+from numpy.testing import assert_almost_equal, assert_equal
+
+from mldftdat.pyscf_utils import get_hf_coul_ex_total, get_hf_coul_ex_total_unrestricted,\
+                                run_scf, run_cc, integrate_on_grid, get_ccsd_ee_total,\
+                                transform_basis_2e, transform_basis_1e, get_ccsd_ee
+import test_analyzers
+from mldftdat.lowmem_analyzers import RHFAnalyzer, UHFAnalyzer, CCSDAnalyzer, UCCSDAnalyzer,\
+                                RKSAnalyzer, UKSAnalyzer
+import numpy as np
+import numbers
+import os
+
+TMP_TEST = 'test_files/tmp'
+
+
+class TestRHFAnalyzer():
+
+    @classmethod
+    def setup_class(cls):
+        cls.mol = gto.Mole(atom='H 0 0 0; F 0 0 1.1', basis = 'sto-3g')
+        cls.mol.build()
+        cls.rhf = run_scf(cls.mol, 'RHF')
+        cls.analyzer = RHFAnalyzer(cls.rhf)
+        cls.ha_tot_ref, cls.fx_tot_ref = get_hf_coul_ex_total(cls.mol, cls.rhf)
+
+    def test_post_process(self):
+        # This is tested in the rest of the module
+        assert_almost_equal(self.ha_tot_ref + self.fx_tot_ref, self.rhf.energy_elec()[1])
+
+    def test_get_ha_energy_density(self):
+        ha_density = self.analyzer.get_ha_energy_density()
+        ha_tot = integrate_on_grid(ha_density, self.analyzer.grid.weights)
+        assert_almost_equal(ha_tot, self.ha_tot_ref, 5)
+        assert_almost_equal(self.analyzer.ha_total, self.ha_tot_ref)
+
+    def test_get_fx_energy_density(self):
+        fx_density = self.analyzer.get_fx_energy_density()
+        fx_tot = integrate_on_grid(fx_density, self.analyzer.grid.weights)
+        assert_almost_equal(fx_tot, self.fx_tot_ref, 5)
+        assert_almost_equal(self.analyzer.fx_total, self.fx_tot_ref)
+
+    def test_get_ee_energy_density(self):
+        ee_density = self.analyzer.get_ee_energy_density()
+        ee_tot = integrate_on_grid(ee_density, self.analyzer.grid.weights)
+        assert_almost_equal(ee_tot, self.rhf.energy_elec()[1], 5)
+
+    def test_as_dict_from_dict(self):
+        analyzer1 = RHFAnalyzer(self.rhf)
+        dict1 = analyzer1.as_dict()
+        analyzer1.get_ha_energy_density()
+        analyzer1.get_fx_energy_density()
+        analyzer1.get_ee_energy_density()
+        dict2 = analyzer1.as_dict()
+        analyzer2 = RHFAnalyzer.from_dict(dict1)
+        analyzer2.get_ha_energy_density()
+        analyzer2.get_fx_energy_density()
+        analyzer2.get_ee_energy_density()
+        assert_almost_equal(analyzer1.ha_energy_density, analyzer2.ha_energy_density)
+        assert_almost_equal(analyzer1.fx_energy_density, analyzer2.fx_energy_density)
+        assert_almost_equal(analyzer1.ee_energy_density, analyzer2.ee_energy_density)
+        analyzer3 = RHFAnalyzer.from_dict(dict2)
+        assert_almost_equal(analyzer1.ha_energy_density, analyzer3.ha_energy_density)
+        assert_almost_equal(analyzer1.fx_energy_density, analyzer3.fx_energy_density)
+        assert_almost_equal(analyzer1.ee_energy_density, analyzer3.ee_energy_density)
+
+    def test_dump_load(self):
+        analyzer1 = RHFAnalyzer(self.rhf)
+        analyzer1.perform_full_analysis()
+        analyzer1.dump(TMP_TEST)
+        analyzer2 = RHFAnalyzer.load(TMP_TEST)
+        for key in analyzer1.__dict__:
+            if isinstance(analyzer1.__getattribute__(key), numbers.Number)\
+                or isinstance(analyzer1.__getattribute__(key), np.ndarray):
+                assert_equal(analyzer1.__getattribute__(key),
+                    analyzer2.__getattribute__(key))
+        data_dict = lib.chkfile.load(TMP_TEST, 'analyzer/data')
+        assert_equal(analyzer1.grid.coords, data_dict['coords'])
+        assert_equal(analyzer1.grid.weights, data_dict['weights'])
+        assert_equal(analyzer1.rho_data, data_dict['rho_data'])
+        assert_equal(analyzer1.tau_data, data_dict['tau_data'])
+        assert_equal(analyzer1.ha_energy_density, data_dict['ha_energy_density'])
+        assert_equal(analyzer1.ee_energy_density, data_dict['ee_energy_density'])
+        os.remove(TMP_TEST)
+
+
+class TestRHFAnalyzerChunks(TestRHFAnalyzer):
+
+    @classmethod
+    def setup_class(cls):
+        cls.mol = gto.Mole(atom='H 0 0 0; F 0 0 1.1', basis = 'sto-3g')
+        cls.mol.build()
+        cls.rhf = run_scf(cls.mol, 'RHF')
+        cls.analyzer = RHFAnalyzer(cls.rhf, max_mem=5)
+        cls.ha_tot_ref, cls.fx_tot_ref = get_hf_coul_ex_total(cls.mol, cls.rhf)
+
+
+class TestRKSAnalyzer():
+
+    @classmethod
+    def setup_class(cls):
+        cls.mol = gto.Mole(atom='H 0 0 0; F 0 0 1.1', basis = 'sto-3g')
+        cls.mol.build()
+        cls.rks = run_scf(cls.mol, 'RHF')
+        cls.analyzer = RKSAnalyzer(cls.rks)
+        cls.rhf = cls.analyzer.calc
+        cls.ha_tot_ref, cls.fx_tot_ref = get_hf_coul_ex_total(cls.mol, cls.rhf)
+
+
+class TestUHFAnalyzer():
+
+    @classmethod
+    def setup_class(cls):
+        cls.mol = gto.Mole(atom='N 0 0 0; O 0 0 1.15', basis = 'sto-3g', spin = 1)
+        cls.mol.build()
+        cls.uhf = run_scf(cls.mol, 'UHF')
+        cls.analyzer = UHFAnalyzer(cls.uhf)
+        cls.ha_tot_ref, cls.fx_tot_ref = get_hf_coul_ex_total_unrestricted(cls.mol, cls.uhf)
+
+    def test_post_process(self):
+        # This is tested in the rest of the module
+        assert_almost_equal(self.ha_tot_ref + self.fx_tot_ref, self.uhf.energy_elec()[1])
+
+    def test_get_ha_energy_density(self):
+        ha_density = self.analyzer.get_ha_energy_density()
+        ha_tot = integrate_on_grid(ha_density, self.analyzer.grid.weights)
+        assert_almost_equal(ha_tot, self.ha_tot_ref, 5)
+        assert_almost_equal(self.analyzer.ha_total, self.ha_tot_ref)
+
+    def test_get_fx_energy_density(self):
+        fx_density = self.analyzer.get_fx_energy_density()
+        fx_tot = integrate_on_grid(fx_density, self.analyzer.grid.weights)
+        assert_almost_equal(fx_tot, self.fx_tot_ref, 5)
+        assert_almost_equal(self.analyzer.fx_total, self.fx_tot_ref)
+
+    def test_get_ee_energy_density(self):
+        ee_density = self.analyzer.get_ee_energy_density()
+        ee_tot = integrate_on_grid(ee_density, self.analyzer.grid.weights)
+        assert_almost_equal(ee_tot, self.uhf.energy_elec()[1], 5)
+
+    def test_as_dict_from_dict(self):
+        analyzer1 = UHFAnalyzer(self.uhf)
+        dict1 = analyzer1.as_dict()
+        analyzer1.get_ha_energy_density()
+        analyzer1.get_fx_energy_density()
+        analyzer1.get_ee_energy_density()
+        dict2 = analyzer1.as_dict()
+        analyzer2 = UHFAnalyzer.from_dict(dict1)
+        analyzer2.get_ha_energy_density()
+        analyzer2.get_fx_energy_density()
+        analyzer2.get_ee_energy_density()
+        assert_almost_equal(analyzer1.ha_energy_density, analyzer2.ha_energy_density)
+        assert_almost_equal(analyzer1.fx_energy_density, analyzer2.fx_energy_density)
+        assert_almost_equal(analyzer1.fx_energy_density_u, analyzer2.fx_energy_density_u)
+        assert_almost_equal(analyzer1.fx_energy_density_d, analyzer2.fx_energy_density_d)
+        assert_almost_equal(analyzer1.ee_energy_density, analyzer2.ee_energy_density)
+        analyzer3 = UHFAnalyzer.from_dict(dict2)
+        assert_almost_equal(analyzer1.ha_energy_density, analyzer3.ha_energy_density)
+        assert_almost_equal(analyzer1.fx_energy_density, analyzer3.fx_energy_density)
+        assert_almost_equal(analyzer1.fx_energy_density_u, analyzer3.fx_energy_density_u)
+        assert_almost_equal(analyzer1.fx_energy_density_d, analyzer3.fx_energy_density_d)
+        assert_almost_equal(analyzer1.ee_energy_density, analyzer3.ee_energy_density)
+
+    def test_dump_load(self):
+        analyzer1 = UHFAnalyzer(self.uhf, require_converged=False)
+        analyzer1.perform_full_analysis()
+        analyzer1.dump(TMP_TEST)
+        analyzer2 = UHFAnalyzer.load(TMP_TEST)
+        for key in analyzer1.__dict__:
+            if isinstance(analyzer1.__getattribute__(key), numbers.Number)\
+                or isinstance(analyzer1.__getattribute__(key), np.ndarray):
+                assert_equal(analyzer1.__getattribute__(key),
+                    analyzer2.__getattribute__(key))
+        data_dict = lib.chkfile.load(TMP_TEST, 'analyzer/data')
+        assert_equal(analyzer1.grid.coords, data_dict['coords'])
+        assert_equal(analyzer1.grid.weights, data_dict['weights'])
+        assert_equal(analyzer1.rho_data, data_dict['rho_data'])
+        assert_equal(analyzer1.tau_data, data_dict['tau_data'])
+        assert_equal(analyzer1.ha_energy_density, data_dict['ha_energy_density'])
+        assert_equal(analyzer1.ee_energy_density, data_dict['ee_energy_density'])
+        os.remove(TMP_TEST)
+
+
+class TestUHFAnalyzerChunks(TestUHFAnalyzer):
+
+    @classmethod
+    def setup_class(cls):
+        cls.mol = gto.Mole(atom='N 0 0 0; O 0 0 1.15', basis = 'sto-3g', spin = 1)
+        cls.mol.build()
+        cls.uhf = run_scf(cls.mol, 'UHF')
+        cls.analyzer = UHFAnalyzer(cls.uhf, max_mem=5)
+        cls.ha_tot_ref, cls.fx_tot_ref = get_hf_coul_ex_total_unrestricted(cls.mol, cls.uhf)
+
+
+class TestUKSAnalyzer(TestUHFAnalyzer):
+
+    @classmethod
+    def setup_class(cls):
+        cls.mol = gto.Mole(atom='N 0 0 0; O 0 0 1.15', basis = 'sto-3g', spin = 1)
+        cls.mol.build()
+        cls.uks = run_scf(cls.mol, 'UKS')
+        cls.analyzer = UKSAnalyzer(cls.uks, require_converged=False)
+        cls.uhf = cls.analyzer.calc
+        cls.ha_tot_ref, cls.fx_tot_ref = get_hf_coul_ex_total_unrestricted(cls.mol, cls.uhf)
+
+    def test_as_dict_from_dict(self):
+        analyzer1 = UHFAnalyzer(self.uhf, require_converged=False)
+        dict1 = analyzer1.as_dict()
+        analyzer1.get_ha_energy_density()
+        analyzer1.get_fx_energy_density()
+        analyzer1.get_ee_energy_density()
+        dict2 = analyzer1.as_dict()
+        analyzer2 = UHFAnalyzer.from_dict(dict1)
+        analyzer2.get_ha_energy_density()
+        analyzer2.get_fx_energy_density()
+        analyzer2.get_ee_energy_density()
+        assert_almost_equal(analyzer1.ha_energy_density, analyzer2.ha_energy_density)
+        assert_almost_equal(analyzer1.fx_energy_density, analyzer2.fx_energy_density)
+        assert_almost_equal(analyzer1.fx_energy_density_u, analyzer2.fx_energy_density_u)
+        assert_almost_equal(analyzer1.fx_energy_density_d, analyzer2.fx_energy_density_d)
+        assert_almost_equal(analyzer1.ee_energy_density, analyzer2.ee_energy_density)
+        analyzer3 = UHFAnalyzer.from_dict(dict2)
+        assert_almost_equal(analyzer1.ha_energy_density, analyzer3.ha_energy_density)
+        assert_almost_equal(analyzer1.fx_energy_density, analyzer3.fx_energy_density)
+        assert_almost_equal(analyzer1.fx_energy_density_u, analyzer3.fx_energy_density_u)
+        assert_almost_equal(analyzer1.fx_energy_density_d, analyzer3.fx_energy_density_d)
+        assert_almost_equal(analyzer1.ee_energy_density, analyzer3.ee_energy_density)
+
+
+class TestCCSDAnalyzer():
+
+    @classmethod
+    def setup_class(cls):
+        cls.mol = gto.Mole(atom='He 0 0 0', basis = 'cc-pvdz')
+        cls.mol.build()
+        cls.hf = run_scf(cls.mol, 'RHF')
+        cls.cc = run_cc(cls.hf)
+        cls.analyzer = CCSDAnalyzer(cls.cc)
+        cls.ee_tot_ref = get_ccsd_ee_total(cls.mol, cls.cc, cls.hf)
+
+    def test_post_process(self):
+        pass
+
+    def test_get_ha_energy_density(self):
+        eri = self.mol.intor('int2e')
+        eri = transform_basis_2e(eri, self.hf.mo_coeff)
+        rdm1 = self.cc.make_rdm1()
+        ha_tot_ref = np.sum(np.sum(eri * rdm1, axis=(2,3)) * rdm1) / 2
+        ha_density = self.analyzer.get_ha_energy_density()
+        ha_tot = integrate_on_grid(ha_density, self.analyzer.grid.weights)
+        assert_almost_equal(ha_tot, ha_tot_ref, 5)
+        assert_almost_equal(self.analyzer.ha_total, ha_tot_ref)
+
+    def test_get_ee_energy_density(self):
+        ee_density = self.analyzer.get_ee_energy_density()
+        ee_tot = integrate_on_grid(ee_density, self.analyzer.grid.weights)
+        assert_almost_equal(ee_tot, self.ee_tot_ref)
+        # ee repulsion should be similar to HF case
+        # Note this case may not pass for all systems, but hsould pass for He and Li
+        assert_almost_equal(ee_tot, self.hf.energy_elec()[1], 1)
+        assert_almost_equal(self.analyzer.ee_total, self.ee_tot_ref)
+
+    def test_as_dict_from_dict(self):
+        analyzer1 = CCSDAnalyzer(self.cc)
+        dict1 = analyzer1.as_dict()
+        analyzer1.get_ha_energy_density()
+        analyzer1.get_ee_energy_density()
+        dict2 = analyzer1.as_dict()
+        analyzer2 = CCSDAnalyzer.from_dict(dict1)
+        analyzer2.get_ha_energy_density()
+        analyzer2.get_ee_energy_density()
+        assert_almost_equal(analyzer1.ha_energy_density, analyzer2.ha_energy_density)
+        assert_almost_equal(analyzer1.ee_energy_density, analyzer2.ee_energy_density)
+        analyzer3 = CCSDAnalyzer.from_dict(dict2)
+        assert_almost_equal(analyzer1.ha_energy_density, analyzer3.ha_energy_density)
+        assert_almost_equal(analyzer1.ee_energy_density, analyzer3.ee_energy_density)
+
+    def test_dump_load(self):
+        analyzer1 = CCSDAnalyzer(self.cc)
+        analyzer1.perform_full_analysis()
+        analyzer1.dump(TMP_TEST)
+        analyzer2 = CCSDAnalyzer.load(TMP_TEST)
+        for key in analyzer1.__dict__:
+            if isinstance(analyzer1.__getattribute__(key), numbers.Number)\
+                or isinstance(analyzer1.__getattribute__(key), np.ndarray):
+                assert_equal(analyzer1.__getattribute__(key),
+                    analyzer2.__getattribute__(key))
+        data_dict = lib.chkfile.load(TMP_TEST, 'analyzer/data')
+        assert_equal(analyzer1.grid.coords, data_dict['coords'])
+        assert_equal(analyzer1.grid.weights, data_dict['weights'])
+        assert_equal(analyzer1.rho_data, data_dict['rho_data'])
+        assert_equal(analyzer1.tau_data, data_dict['tau_data'])
+        assert_equal(analyzer1.ha_energy_density, data_dict['ha_energy_density'])
+        assert_equal(analyzer1.ee_energy_density, data_dict['ee_energy_density'])
+        os.remove(TMP_TEST)
+
+
+class TestCCSDAnalyzerChunks(TestCCSDAnalyzer):
+
+    @classmethod
+    def setup_class(cls):
+        cls.mol = gto.Mole(atom='He 0 0 0', basis = 'cc-pvdz')
+        cls.mol.build()
+        cls.hf = run_scf(cls.mol, 'RHF')
+        cls.cc = run_cc(cls.hf)
+        cls.analyzer = CCSDAnalyzer(cls.cc, max_mem=5)
+        cls.ee_tot_ref = get_ccsd_ee_total(cls.mol, cls.cc, cls.hf)
+
+
+class TestUCCSDAnalyzer():
+
+    @classmethod
+    def setup_class(cls):
+        cls.mol = gto.Mole(atom='Li 0 0 0', basis = 'cc-pvdz', spin=1)
+        cls.mol.build()
+        cls.hf = run_scf(cls.mol, 'UHF')
+        cls.cc = run_cc(cls.hf)
+        cls.analyzer = UCCSDAnalyzer(cls.cc)
+        cls.ee_tot_ref = get_ccsd_ee_total(cls.mol, cls.cc, cls.hf)
+
+    def test_post_process(self):
+        pass
+
+    def test_get_ha_energy_density(self):
+        eri = self.mol.intor('int2e')
+        rdm1 = self.cc.make_rdm1()
+        rdm1 = transform_basis_1e(rdm1, np.transpose(self.hf.mo_coeff, axes=(0,2,1)))
+        rdm1 = np.sum(rdm1, axis=0)
+        ha_tot_ref = np.sum(np.sum(eri * rdm1, axis=(2,3)) * rdm1) / 2
+        ha_density = self.analyzer.get_ha_energy_density()
+        ha_tot = integrate_on_grid(ha_density, self.analyzer.grid.weights)
+        assert_almost_equal(ha_tot, ha_tot_ref)
+        assert_almost_equal(self.analyzer.ha_total, ha_tot_ref)
+
+    def test_get_ee_energy_density(self):
+        ee_density = self.analyzer.get_ee_energy_density()
+        ee_tot = integrate_on_grid(ee_density, self.analyzer.grid.weights)
+        assert_almost_equal(ee_tot, self.ee_tot_ref)
+        # ee repulsion should be similar to HF case
+        # Note this case may not pass for all systems, but hsould pass for He and Li
+        assert_almost_equal(ee_tot, self.hf.energy_elec()[1], 1)
+        assert_almost_equal(self.analyzer.ee_total, self.ee_tot_ref)
+
+    def test_as_dict_from_dict(self):
+        analyzer1 = UCCSDAnalyzer(self.cc)
+        dict1 = analyzer1.as_dict()
+        analyzer1.get_ha_energy_density()
+        analyzer1.get_ee_energy_density()
+        dict2 = analyzer1.as_dict()
+        analyzer2 = UCCSDAnalyzer.from_dict(dict1)
+        analyzer2.get_ha_energy_density()
+        analyzer2.get_ee_energy_density()
+        assert_almost_equal(analyzer1.ha_energy_density, analyzer2.ha_energy_density)
+        assert_almost_equal(analyzer1.ee_energy_density, analyzer2.ee_energy_density)
+        assert_almost_equal(analyzer1.ee_energy_density_uu, analyzer2.ee_energy_density_uu)
+        assert_almost_equal(analyzer1.ee_energy_density_ud, analyzer2.ee_energy_density_ud)
+        assert_almost_equal(analyzer1.ee_energy_density_dd, analyzer2.ee_energy_density_dd)
+        analyzer3 = UCCSDAnalyzer.from_dict(dict2)
+        assert_almost_equal(analyzer1.ha_energy_density, analyzer3.ha_energy_density)
+        assert_almost_equal(analyzer1.ee_energy_density, analyzer3.ee_energy_density)
+        assert_almost_equal(analyzer1.ee_energy_density_uu, analyzer3.ee_energy_density_uu)
+        assert_almost_equal(analyzer1.ee_energy_density_ud, analyzer3.ee_energy_density_ud)
+        assert_almost_equal(analyzer1.ee_energy_density_dd, analyzer3.ee_energy_density_dd)
+
+    def test_dump_load(self):
+        analyzer1 = UCCSDAnalyzer(self.cc)
+        analyzer1.perform_full_analysis()
+        analyzer1.dump(TMP_TEST)
+        analyzer2 = UCCSDAnalyzer.load(TMP_TEST)
+        for key in analyzer1.__dict__:
+            if isinstance(analyzer1.__getattribute__(key), numbers.Number)\
+                or isinstance(analyzer1.__getattribute__(key), np.ndarray):
+                assert_equal(analyzer1.__getattribute__(key),
+                    analyzer2.__getattribute__(key))
+        data_dict = lib.chkfile.load(TMP_TEST, 'analyzer/data')
+        assert_equal(analyzer1.grid.coords, data_dict['coords'])
+        assert_equal(analyzer1.grid.weights, data_dict['weights'])
+        assert_equal(analyzer1.rho_data, data_dict['rho_data'])
+        assert_equal(analyzer1.tau_data, data_dict['tau_data'])
+        assert_equal(analyzer1.ha_energy_density, data_dict['ha_energy_density'])
+        assert_equal(analyzer1.ee_energy_density, data_dict['ee_energy_density'])
+        os.remove(TMP_TEST)
+
+
+class TestUCCSDAnalyzerChunks(TestUCCSDAnalyzer):
+
+    @classmethod
+    def setup_class(cls):
+        cls.mol = gto.Mole(atom='Li 0 0 0', basis = 'cc-pvdz', spin=1)
+        cls.mol.build()
+        cls.hf = run_scf(cls.mol, 'UHF')
+        cls.cc = run_cc(cls.hf)
+        cls.analyzer = UCCSDAnalyzer(cls.cc, max_mem=5)
+        cls.ee_tot_ref = get_ccsd_ee_total(cls.mol, cls.cc, cls.hf)
+

--- a/mldftdat/tests/test_pyscf_utils.py
+++ b/mldftdat/tests/test_pyscf_utils.py
@@ -267,10 +267,8 @@ class TestPyscfUtils(unittest.TestCase):
         rha_ref = get_ha_energy_density(self.FH, self.rhf_rdm1,
                                     self.rhf_vele_mat, self.rhf_ao_vals)
 
-        vele_mat_gen1 = get_vele_mat_generator(self.FH, self.rhf_grid.coords,
-                                               2, self.rhf_ao_vals)
-        vele_mat_gen2 = get_vele_mat_generator(self.FH, self.rhf_grid.coords,
-                                               13, self.rhf_ao_vals)
+        vele_mat_gen1 = get_vele_mat_generator(self.FH, self.rhf_grid.coords, 2)
+        vele_mat_gen2 = get_vele_mat_generator(self.FH, self.rhf_grid.coords, 13)
 
         rha1 = get_ha_energy_density2(self.FH, self.rhf_rdm1,
                                     self.rhf_vele_mat, self.rhf_ao_vals)


### PR DESCRIPTION
The lowmem analyzers are implemented, and the pyscf_tasks module is edited to use these modules when the basis set is too big. However, These may be of limited use due to taking up so much disk space that it runs out of that too. They do produce the same results as the standard version though, so I will keep them around.