### PR TITLE
coupled cluster energy density

### DIFF
--- a/mldftdat/pyscf_utils.py
+++ b/mldftdat/pyscf_utils.py
@@ -338,6 +338,30 @@ def get_ee_energy_density(mol, rdm2, vele_mat, orb_vals):
     Vele = np.einsum('pi,pi->p', tmp, orb_vals)
     return 0.5 * Vele
 
+def get_corr_energy_density(mol, tau, vele_mat_ov, orbvals_occ,
+                            orbvals_vir, direct = True):
+    """
+    Get the coupled-cluster correlation energy density for a system
+    and basis set(mol), for a given molecular structu with basis set (mol).
+    Args:
+        tau (nocc,nocc,nvir,nvir)
+        vele_mat_ov(gridsize,nocc,nvir)
+        orbvals_occ (gridsize,nocc)
+        orbvals_occ (gridsize,nvir)
+    """
+    if direct:
+        vele_tmp = np.einsum('ijab,pia->pjb', tau, vele_mat_ov)
+    else:
+        vele_tmp = np.einsum('jiab,pia->pjb', tau, vele_mat_ov)
+    vele_tmp = np.einsum('pjb,pb->pj', vele_tmp, orbvals_vir)
+    vele = np.einsum('pj,pj->p', vele_tmp, orbvals_occ)
+
+    return vele
+
+    #e += 2 * numpy.einsum('ijab,iabj', tau, eris_ovvo)
+    #e -=     numpy.einsum('jiab,iabj', tau, eris_ovvo)
+
+
 
 # The following functions are helpers that check whether vele_mat
 # is a numpy array or a generator before passing to the methods

--- a/mldftdat/pyscf_utils.py
+++ b/mldftdat/pyscf_utils.py
@@ -353,15 +353,15 @@ def get_corr_energy_density(mol, tau, vele_mat_ov, orbvals_occ,
     Get the coupled-cluster correlation energy density for a system
     and basis set(mol), for a given molecular structu with basis set (mol).
     Args:
-        tau (nocc,nocc,nvir,nvir)
-        vele_mat_ov(gridsize,nocc,nvir)
-        orbvals_occ (gridsize,nocc)
-        orbvals_occ (gridsize,nvir)
+        tau (nocc1,nocc2,nvir1,nvir2)
+        vele_mat_ov(gridsize,nocc2,nvir2)
+        orbvals_occ (gridsize,nocc1)
+        orbvals_occ (gridsize,nvir1)
     """
     if direct:
-        vele_tmp = np.einsum('ijab,pia->pjb', tau, vele_mat_ov)
+        vele_tmp = np.einsum('ijab,pjb->pia', tau, vele_mat_ov)
     else:
-        vele_tmp = np.einsum('jiab,pia->pjb', tau, vele_mat_ov)
+        vele_tmp = np.einsum('jiab,pjb->pia', tau, vele_mat_ov)
     vele_tmp = np.einsum('pjb,pb->pj', vele_tmp, orbvals_vir)
     vele = np.einsum('pj,pj->p', vele_tmp, orbvals_occ)
 

--- a/mldftdat/tests/test_analyzers.py
+++ b/mldftdat/tests/test_analyzers.py
@@ -260,6 +260,31 @@ class TestCCSDAnalyzer():
     def test_post_process(self):
         pass
 
+    def test_expected_values(self):
+        rdm1 = self.analyzer.rdm1
+        rdm2 = self.analyzer.rdm2
+        mo_rdm1 = self.analyzer.mo_rdm1
+        mo_rdm2 = self.analyzer.mo_rdm2
+        nelec = self.mol.nelectron
+        ntot = 0
+        for i in range(mo_rdm2.shape[0]):
+            for j in range(mo_rdm2.shape[1]):
+                ntot += mo_rdm2[i,i,j,j]
+        #shape = mo_rdm2.shape
+        #mo_rdm2 = np.reshape(mo_rdm2, (shape[0]*shape[1], shape[2]*shape[3]))
+        assert_almost_equal(np.einsum('ii', mo_rdm1), nelec)
+        assert_almost_equal(np.einsum('iijj', mo_rdm2), nelec*(nelec-1))
+        esum = np.dot(self.hf.mo_occ, self.hf.mo_energy)
+        hcore = scf.hf.get_hcore(self.mol)
+        e_tot = np.einsum('ij,ij', hcore, rdm1) \
+                + 0.5 * np.einsum('ijkl,ijkl', self.analyzer.eri_ao, rdm2)
+        assert_almost_equal(e_tot, self.analyzer.e_tot)
+
+    def test_get_corr_energy_density(self):
+        ecorr_dens = self.analyzer.get_corr_energy_density()
+        ecorr = integrate_on_grid(ecorr_dens, self.analyzer.grid.weights)
+        assert_almost_equal(ecorr, self.analyzer.calc.e_corr)
+
     def test_get_ha_energy_density(self):
         eri = self.mol.intor('int2e')
         eri = transform_basis_2e(eri, self.hf.mo_coeff)

--- a/mldftdat/tests/test_analyzers.py
+++ b/mldftdat/tests/test_analyzers.py
@@ -365,6 +365,11 @@ class TestUCCSDAnalyzer():
     def test_post_process(self):
         pass
 
+    def test_get_corr_energy_density(self):
+        ecorr_dens = self.analyzer.get_corr_energy_density()
+        ecorr = integrate_on_grid(ecorr_dens, self.analyzer.grid.weights)
+        assert_almost_equal(ecorr, self.analyzer.calc.e_corr)
+
     def test_get_ha_energy_density(self):
         eri = self.mol.intor('int2e')
         rdm1 = self.cc.make_rdm1()


### PR DESCRIPTION
This addition allows the coupled cluster correlation energy density. NOT strictly equivalent to any density functional quantity unless rho[cc]=rho[hf], in which case it is equal to the Hohenberg-Kohn correlation energy density).